### PR TITLE
[ZNTA-306] Configuration to allow periodic check for new translation

### DIFF
--- a/tmgmt_zanata.module
+++ b/tmgmt_zanata.module
@@ -47,3 +47,42 @@ function tmgmt_zanata_poll_translations($form, &$form_state) {
   $job = $form_state['tmgmt_job'];
   $job->getTranslatorController()->getConnector($job)->pollTranslations();
 }
+
+/**
+ * Implements hook_cron().
+ *
+ * Cron based callback used to poll for translations
+ */
+function tmgmt_zanata_cron(){
+    if (variable_get('poll_translations_during_cron', TRUE)) {
+        $query = new EntityFieldQuery();
+        $result = $query->entityCondition('entity_type', 'tmgmt_job')->propertyCondition('state',
+            TMGMT_JOB_STATE_ACTIVE)->propertyCondition('translator', 'zanata')->execute();
+
+        if (!empty($result['tmgmt_job'])) {
+            $active_translation_jobs = array_keys($result['tmgmt_job']);
+            $queue = DrupalQueue::get('poll_trans');
+            foreach ($active_translation_jobs as $job_id) {
+                $queue->createItem($job_id);
+            }
+        }
+    }
+}
+
+/*
+ * Implements hook_cron_queue_info().
+ */
+function tmgmt_zanata_cron_queue_info(){
+    $queues['poll_trans'] = array(
+        'worker callback' => 'poll_translation',
+        'time' => 120,
+    );
+    return $queues;
+}
+
+function poll_translation($job_id){
+    $job = tmgmt_job_load($job_id);
+    if ($job->getTranslator()->getSetting('transcheck')) {
+        $job->getTranslatorController()->getConnector($job)->pollTranslations();
+    }
+}

--- a/tmgmt_zanata.ui.inc
+++ b/tmgmt_zanata.ui.inc
@@ -69,7 +69,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
       '#type' => 'checkbox',
       '#title' => t('Translation Periodic Check'),
       '#description' => t(
-        'Pull translations delta automatically.'),
+        'Automatically fetch new translations every time cron runs.'),
       '#default_value' => $translator->getSetting('transcheck'),
     );
     $form['segmentation'] = array(

--- a/tmgmt_zanata.ui.inc
+++ b/tmgmt_zanata.ui.inc
@@ -23,7 +23,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
     $form['server'] = array(
       // TODO check whether there is a specific type for URLs.
       '#type' => 'textfield',
-      '#title' => t('Zanata server URL'),
+      '#title' => t('Zanata Server URL'),
       '#description' => t(
         'Base URL for the Zanata server. This should not include a / at the end, for example, http://translate.zanata.org/zanata'),
       '#size' => 120,
@@ -32,7 +32,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
     );
     $form['username'] = array(
       '#type' => 'textfield',
-      '#title' => t('username'),
+      '#title' => t('Zanata Username'),
       '#description' => t('Your username on Zanata.'),
       '#size' => 20,
       '#maxlength' => 20,
@@ -40,7 +40,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
     );
     $form['api_key'] = array(
       '#type' => 'textfield',
-      '#title' => t('API key'),
+      '#title' => t('Zanata API Key'),
       '#description' => t(
         'Your API key on Zanata, found in the "Client" section of your user settings (via the dashboard).'),
       '#size' => 32,
@@ -64,6 +64,13 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
       '#size' => 40,
       '#maxlength' => 40,
       '#default_value' => $translator->getSetting('version'),
+    );
+    $form['transcheck'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Translation Periodic Check'),
+      '#description' => t(
+        'Pull translations delta automatically.'),
+      '#default_value' => $translator->getSetting('transcheck'),
     );
     $form['segmentation'] = array(
       '#type' => 'select',


### PR DESCRIPTION
This enables TMGMT plugin to pull translations delta (drupal cron based) from server if `Translation Periodic Check` is enabled. And if `Auto accept finished translations` is also enabled it would be published automatically upon 100% translation of messages.

@davidmason Please have a look.