### PR TITLE
ZNTA-996: Send email when translations are requested

### DIFF
--- a/tmgmt_zanata.connector.inc
+++ b/tmgmt_zanata.connector.inc
@@ -898,8 +898,8 @@ class TmgmtZanataConnector {
         $msgBody .= "<tr>";
         $msgBody .= "<td>" . $content['docTitle'] . "</td>";
         $msgBody .= "<td>" . $content['docName'] . "</td>";
-        $msgBody .= "<td>" . $content['zanataURL'] . "</td>";
-        $msgBody .= "<td>" . $content['drupalURL'] . "</td>";
+        $msgBody .= "<td><a href=\"" . $content['zanataURL'] . "\">translate in Zanata</a></td>";
+        $msgBody .= "<td><a href=\"" . $content['drupalURL'] . "\">view source document</a></td>";
         $msgBody .= "</tr>";
       }
 

--- a/tmgmt_zanata.connector.inc
+++ b/tmgmt_zanata.connector.inc
@@ -445,11 +445,11 @@ class TmgmtZanataConnector {
         t('All items have been submitted to Zanata for translation.'));
 
       // Send email notification
-      $notificationEmail = $this->job->getTranslator()->getSetting('emailaddress');
+      $notificationEmail = $this->job->getTranslator()->getSetting('group1')['emailaddress'];
       $emailSubject = 'Translation job submitted to Zanata for locale: '.$this->getLocale();
       $body = $this->formatEmailBody($email_contents);
 
-      if ($this->job->getTranslator()->getSetting('emailnotification') and $notificationEmail){
+      if ($this->job->getTranslator()->getSetting('group1')['emailnotification'] and $notificationEmail){
         $this->send_drupal_mail('default_from', $notificationEmail, $emailSubject, $body);
       }
     }
@@ -879,11 +879,15 @@ class TmgmtZanataConnector {
    * Function to format notification email body
    */
   private function formatEmailBody($email_contents, $type='PLAIN'){
+    $title = drupal_get_title();
+    $site_name = variable_get('site_name', "Drupal");
+    $page_title = $title." | ".$site_name;
+    $msg = "A translation job has been submitted to Zanata from '".$page_title."'. Details:";
     if ($type === 'HTML') {
       $msgBody = "<html><body>";
       $msgBody .= "<h3>Hello,</h3>";
       $msgBody .= "<br/><br/>";
-      $msgBody .= "A translation job has been submitted to Zanata. Details:";
+      $msgBody .= $msg;
       $msgBody .= "<br/>";
       $msgBody .= "Locale: ".$this->getLocale();
       $msgBody .= "<br/>";
@@ -910,7 +914,7 @@ class TmgmtZanataConnector {
     }
     else {
       $msgBody = "Hello,\n\n";
-      $msgBody .= "A translation job has been submitted to Zanata. Details:\n";
+      $msgBody .= $msg."\n";
       $msgBody .= "Locale: ".$this->getLocale()."\n\n";
       $msgBody .= "Documents...\n\n";
       foreach ($email_contents as $content) {

--- a/tmgmt_zanata.connector.inc
+++ b/tmgmt_zanata.connector.inc
@@ -64,6 +64,16 @@ class TmgmtZanataConnector {
   }
 
   /**
+   * Generate the URL for the translation editor in Zanata for a Doc.
+   *
+   * This will be the URL to the document in the editor, ready for a node
+   * to be translated.
+   */
+  public function getDocEditorUrl($docName) {
+    return $this->getEditorUrl().'#view:doc;doc:'.$docName;
+  }
+
+  /**
    * Generate a base URL for documents in a project/version.
    *
    * @return string
@@ -391,6 +401,7 @@ class TmgmtZanataConnector {
     $sent_translations_for_how_many = 0;
     $base_options = $this->getBaseOptions();
     $base_options['method'] = 'PUT';
+    $email_contents = Array();
 
     // TODO record successful translation submission and skip it next time
     //      (may already be handled with the submitted check, but don't want
@@ -407,6 +418,19 @@ class TmgmtZanataConnector {
         }
       }
 
+      $docNode = $job_item->item_type.'/'.$job_item->item_id;
+      $docTitle = $job_item->data['node_title']['#text'];
+      $docTitleWithUnderscore = str_replace(' ', '_', $docTitle);
+      $docName = $docNode.'/'.$docTitleWithUnderscore;
+
+      $docDetails = array(
+        'docTitle' => $docTitle, 'docName' => $docName,
+        'zanataURL' => $this->getDocEditorUrl($docName),
+        'drupalURL' => $_SERVER['RUNSERVER_BASE_URL'].'/'.$docNode
+      );
+
+      array_push($email_contents, $docDetails);
+
       $submitted = $this->requestItemTranslation($job_item, $base_options);
       $all_submissions_worked = $submitted && $all_submissions_worked;
 
@@ -419,6 +443,15 @@ class TmgmtZanataConnector {
     if ($all_submissions_worked) {
       $this->job->submitted(
         t('All items have been submitted to Zanata for translation.'));
+
+      // Send email notification
+      $notificationEmail = $this->job->getTranslator()->getSetting('emailaddress');
+      $emailSubject = 'Translation job submitted to Zanata for locale: '.$this->getLocale();
+      $body = $this->formatEmailBody($email_contents);
+
+      if ($this->job->getTranslator()->getSetting('emailnotification') and $notificationEmail){
+        $this->send_drupal_mail('default_from', $notificationEmail, $emailSubject, $body);
+      }
     }
     else {
       // TODO include count of failed items.
@@ -840,6 +873,90 @@ class TmgmtZanataConnector {
       'extensions' => array(),
       'revision' => 1,
     );
+  }
+
+  /**
+   * Function to format notification email body
+   */
+  private function formatEmailBody($email_contents, $type='PLAIN'){
+    if ($type === 'HTML') {
+      $msgBody = "<html><body>";
+      $msgBody .= "<h3>Hello,</h3>";
+      $msgBody .= "<br/><br/>";
+      $msgBody .= "A translation job has been submitted to Zanata. Details:";
+      $msgBody .= "<br/>";
+      $msgBody .= "Locale: ".$this->getLocale();
+      $msgBody .= "<br/>";
+      $msgBody .= "Documents...";
+      $msgBody .= "<br/>";
+      $msgBody .= "<table rules='all' style='border-color: #666;' cellpadding='10'>";
+      $msgBody .= "<tr align='left' style='background: #eee;'><td><strong>Title</strong></td>";
+      $msgBody .= "<td><strong>Name in Zanata</strong></td>";
+      $msgBody .= "<td><strong>Zanata URL</strong></td><td><strong>Drupal URL</strong></td></tr>";
+
+      foreach ($email_contents as $content) {
+        $msgBody .= "<tr>";
+        $msgBody .= "<td>" . $content['docTitle'] . "</td>";
+        $msgBody .= "<td>" . $content['docName'] . "</td>";
+        $msgBody .= "<td>" . $content['zanataURL'] . "</td>";
+        $msgBody .= "<td>" . $content['drupalURL'] . "</td>";
+        $msgBody .= "</tr>";
+      }
+
+      $msgBody .= "</table>";
+      $msgBody .= "<br/><br/>";
+      $msgBody .= "Zanata Team";
+      $msgBody .= "</body></html>";
+    }
+    else {
+      $msgBody = "Hello,\n\n";
+      $msgBody .= "A translation job has been submitted to Zanata. Details:\n";
+      $msgBody .= "Locale: ".$this->getLocale()."\n\n";
+      $msgBody .= "Documents...\n\n";
+      foreach ($email_contents as $content) {
+        $msgBody .= "Doc Title: ".$content['docTitle']."\n";
+        $msgBody .= "Name in Zanata: ".$content['docName']."\n";
+        $msgBody .= "Zanata URL: ".$content['zanataURL']."\n";
+        $msgBody .= "Drupal URL: ".$content['drupalURL']."\n\n";
+      }
+      $msgBody .= "\n";
+      $msgBody .= "Zanata Team";
+    }
+    return $msgBody;
+  }
+
+  /**
+   * Simple wrapper function for drupal_mail()
+   */
+  public function send_drupal_mail($from = 'default_from', $to, $subject, $message) {
+    $module = 'tmgmt_zanata';
+    $mail_token = microtime();
+    if ($from == 'default_from') {
+      $from = variable_get('system_mail', 'noreply@zanata.org');
+    }
+    $message = array(
+        'id' => $module . '_' . $mail_token,
+        'to' => $to,
+        'subject' => $subject,
+        'body' => array($message),
+        'headers' => array(
+            'From' => $from,
+            'Sender' => $from,
+            'Return-Path' => $from,
+            'MIME-Version' => '1.0',
+            'Content-Type' => "text/plain; charset=UTF-8",
+            'Content-Transfer-Encoding' => '8Bit',
+            'X-Mailer' => 'Drupal'
+        ),
+    );
+    $system = drupal_mail_system($module, $mail_token);
+    $message = $system->format($message);
+    if ($system->mail($message)) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
   }
 
 }

--- a/tmgmt_zanata.module
+++ b/tmgmt_zanata.module
@@ -47,3 +47,42 @@ function tmgmt_zanata_poll_translations($form, &$form_state) {
   $job = $form_state['tmgmt_job'];
   $job->getTranslatorController()->getConnector($job)->pollTranslations();
 }
+
+/**
+ * Implements hook_cron().
+ *
+ * Cron based callback used to poll for translations
+ */
+function tmgmt_zanata_cron(){
+    if (variable_get('poll_translations_during_cron', TRUE)) {
+        $query = new EntityFieldQuery();
+        $result = $query->entityCondition('entity_type', 'tmgmt_job')->propertyCondition('state',
+            TMGMT_JOB_STATE_ACTIVE)->propertyCondition('translator', 'zanata')->execute();
+
+        if (!empty($result['tmgmt_job'])) {
+            $active_translation_jobs = array_keys($result['tmgmt_job']);
+            $queue = DrupalQueue::get('poll_trans');
+            foreach ($active_translation_jobs as $job_id) {
+                $queue->createItem($job_id);
+            }
+        }
+    }
+}
+
+/*
+ * Implements hook_cron_queue_info().
+ */
+function tmgmt_zanata_cron_queue_info(){
+    $queues['poll_trans'] = array(
+        'worker callback' => 'poll_translation',
+        'time' => 120,
+    );
+    return $queues;
+}
+
+function poll_translation($job_id){
+    $job = tmgmt_job_load($job_id);
+    if ($job->getTranslator()->getSetting('transcheck')) {
+        $job->getTranslatorController()->getConnector($job)->pollTranslations();
+    }
+}

--- a/tmgmt_zanata.ui.inc
+++ b/tmgmt_zanata.ui.inc
@@ -72,14 +72,20 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
         'Automatically fetch new translations every time cron runs.'),
       '#default_value' => $translator->getSetting('transcheck'),
     );
-    $form['emailnotification'] = array(
+    $form['group1'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Notification'),
+        '#collapsible' => FALSE,
+        '#collapsed' => FALSE,
+    );
+    $form['group1']['emailnotification'] = array(
         '#type' => 'checkbox',
         '#title' => t('Send an email when a job is created'),
         '#description' => t(
-            'Automatically send an email every time job is created.'),
+            'The email shows the requested language, and a list of documents with links to view the source and translations.'),
         '#default_value' => $translator->getSetting('emailnotification'),
     );
-    $form['emailaddress'] = array(
+    $form['group1']['emailaddress'] = array(
         '#type' => 'textfield',
         '#title' => t('Email address to send to when a job is created'),
         '#states' => array(

--- a/tmgmt_zanata.ui.inc
+++ b/tmgmt_zanata.ui.inc
@@ -69,7 +69,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
       '#type' => 'checkbox',
       '#title' => t('Translation Periodic Check'),
       '#description' => t(
-        'Pull translations delta automatically.'),
+        'Automatically fetch new translations every time cron runs.'),
       '#default_value' => $translator->getSetting('transcheck'),
     );
     $form['segmentation'] = array(

--- a/tmgmt_zanata.ui.inc
+++ b/tmgmt_zanata.ui.inc
@@ -23,7 +23,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
     $form['server'] = array(
       // TODO check whether there is a specific type for URLs.
       '#type' => 'textfield',
-      '#title' => t('Zanata server URL'),
+      '#title' => t('Zanata Server URL'),
       '#description' => t(
         'Base URL for the Zanata server. This should not include a / at the end, for example, http://translate.zanata.org/zanata'),
       '#size' => 120,
@@ -32,7 +32,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
     );
     $form['username'] = array(
       '#type' => 'textfield',
-      '#title' => t('username'),
+      '#title' => t('Zanata Username'),
       '#description' => t('Your username on Zanata.'),
       '#size' => 20,
       '#maxlength' => 20,
@@ -40,7 +40,7 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
     );
     $form['api_key'] = array(
       '#type' => 'textfield',
-      '#title' => t('API key'),
+      '#title' => t('Zanata API Key'),
       '#description' => t(
         'Your API key on Zanata, found in the "Client" section of your user settings (via the dashboard).'),
       '#size' => 32,
@@ -64,6 +64,13 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
       '#size' => 40,
       '#maxlength' => 40,
       '#default_value' => $translator->getSetting('version'),
+    );
+    $form['transcheck'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Translation Periodic Check'),
+      '#description' => t(
+        'Pull translations delta automatically.'),
+      '#default_value' => $translator->getSetting('transcheck'),
     );
     $form['segmentation'] = array(
       '#type' => 'select',

--- a/tmgmt_zanata.ui.inc
+++ b/tmgmt_zanata.ui.inc
@@ -72,6 +72,26 @@ class TMGMTZanataTranslatorUIController extends TMGMTDefaultTranslatorUIControll
         'Automatically fetch new translations every time cron runs.'),
       '#default_value' => $translator->getSetting('transcheck'),
     );
+    $form['emailnotification'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Send an email when a job is created'),
+        '#description' => t(
+            'Automatically send an email every time job is created.'),
+        '#default_value' => $translator->getSetting('emailnotification'),
+    );
+    $form['emailaddress'] = array(
+        '#type' => 'textfield',
+        '#title' => t('Email address to send to when a job is created'),
+        '#states' => array(
+            "visible" => array(
+                "input[name='emailnotification']" => array("checked" => TRUE)),
+        ),
+        '#description' => t(
+            'Notification will be posted to this email address when a job is created.'),
+        '#size' => 50,
+        '#maxlength' => 50,
+        '#default_value' => $translator->getSetting('emailaddress'),
+    );
     $form['segmentation'] = array(
       '#type' => 'select',
       '#title' => t('Segmentation'),


### PR DESCRIPTION
An option to send an email to a configured email address whenever a translation job is created.
This patch requires **smtp** module to be enabled and working.

@davidmason Please have a look.